### PR TITLE
doze: remove screen_gestures_panel_summary

### DIFF
--- a/doze/AndroidManifest.xml
+++ b/doze/AndroidManifest.xml
@@ -39,9 +39,6 @@
             <meta-data
                 android:name="com.android.settings.title"
                 android:resource="@string/screen_gestures_panel_title"/>
-            <meta-data
-                android:name="com.android.settings.summary"
-                android:resource="@string/screen_gestures_panel_summary"/>
         </activity>
 
     </application>

--- a/doze/res/values-af/strings.xml
+++ b/doze/res/values-af/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gebare</string>
-  <string name="screen_gestures_panel_summary">Gebruik gebare om aksies uit te oefen</string>
   <string name="ambient_display_title">Omgewings skerm</string>
   <string name="ambient_display_enable_title">Omgewings skerm</string>
   <string name="ambient_display_enable_summary">Skerm sal wakker word wanneer jy kennisgewings ontvang</string>

--- a/doze/res/values-ast-rES/strings.xml
+++ b/doze/res/values-ast-rES/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Xestos</string>
-  <string name="screen_gestures_panel_summary">Usa xestos pa facer aiciones</string>
   <string name="ambient_display_title">Pantalla ambiente</string>
   <string name="ambient_display_enable_title">Pantalla ambiente</string>
   <string name="ambient_display_enable_summary">Prender pantalla al recibir avisos</string>

--- a/doze/res/values-az-rAZ/strings.xml
+++ b/doze/res/values-az-rAZ/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Jestlər</string>
-  <string name="screen_gestures_panel_summary">Əməliyyatı həyata keçirmək üçün jestlərdən istifadə edin</string>
   <string name="ambient_display_title">Ekran mühiti</string>
   <string name="ambient_display_enable_title">Ekran mühiti</string>
   <string name="ambient_display_enable_summary">Bildiriş gələndə ekranı oyandırar</string>

--- a/doze/res/values-ca/strings.xml
+++ b/doze/res/values-ca/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestos</string>
-  <string name="screen_gestures_panel_summary">Utilitza gestos per realitzar accions</string>
   <string name="ambient_display_title">Pantalla ambient</string>
   <string name="ambient_display_enable_title">Pantalla ambient</string>
   <string name="ambient_display_enable_summary">Encen la pantalla quan rebis notificacions</string>

--- a/doze/res/values-cs/strings.xml
+++ b/doze/res/values-cs/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gesta</string>
-  <string name="screen_gestures_panel_summary">Používat gesta k provedení akce</string>
   <string name="ambient_display_title">Ambientní zobrazení</string>
   <string name="ambient_display_enable_title">Ambientní zobrazení</string>
   <string name="ambient_display_enable_summary">Probudit obrazovku při upozornění</string>

--- a/doze/res/values-da/strings.xml
+++ b/doze/res/values-da/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Bevægelser</string>
-  <string name="screen_gestures_panel_summary">Anvend bevægelser til at udføre handlinger</string>
   <string name="ambient_display_title">Inaktivitetsvisning</string>
   <string name="ambient_display_enable_title">Inaktivitetsvisning</string>
   <string name="ambient_display_enable_summary">Tænder skærmen, når du modtager notifikationer</string>

--- a/doze/res/values-de/strings.xml
+++ b/doze/res/values-de/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gesten</string>
-  <string name="screen_gestures_panel_summary">Gesten verwenden, um Aktionen auszuführen</string>
   <string name="ambient_display_title">Inaktivitätsdisplay</string>
   <string name="ambient_display_enable_title">Inaktivitätsdisplay</string>
   <string name="ambient_display_enable_summary">Bildschirm wecken, wenn Sie Benachrichtigungen erhalten</string>

--- a/doze/res/values-el/strings.xml
+++ b/doze/res/values-el/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Χειρονομίες</string>
-  <string name="screen_gestures_panel_summary">Χρησιμοποιήστε χειρονομίες για να εκτελέσετε ενέργειες</string>
   <string name="ambient_display_title">Οθόνη ambient</string>
   <string name="ambient_display_enable_title">Οθόνη ambient</string>
   <string name="ambient_display_enable_summary">Ενεργοποίηση της οθόνης όταν λαμβάνετε ειδοποιήσεις</string>

--- a/doze/res/values-eo/strings.xml
+++ b/doze/res/values-eo/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestoj</string>
-  <string name="screen_gestures_panel_summary">Uzi gestojn por agi</string>
   <string name="ambient_display_title">Ĉirkaŭaĵa afiŝado</string>
   <string name="ambient_display_enable_title">Ĉirkaŭaĵa afiŝado</string>
   <string name="ambient_display_enable_summary">Vekigi ekranon, kiam vi ricevas atentigojn</string>

--- a/doze/res/values-es/strings.xml
+++ b/doze/res/values-es/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestos</string>
-  <string name="screen_gestures_panel_summary">Utilizar gestos para realizar acciones</string>
   <string name="ambient_display_title">Pantalla ambiente</string>
   <string name="ambient_display_enable_title">Pantalla ambiente</string>
   <string name="ambient_display_enable_summary">Activa la pantalla cuando recibes notificaciones</string>

--- a/doze/res/values-et-rEE/strings.xml
+++ b/doze/res/values-et-rEE/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Žestid</string>
-  <string name="screen_gestures_panel_summary">Kasuta žeste toimingute sooritamiseks</string>
   <string name="ambient_display_title">Ambient kuva</string>
   <string name="ambient_display_enable_title">Ambient kuva</string>
   <string name="ambient_display_enable_summary">Ärata ekraan teavituste saabumisel</string>

--- a/doze/res/values-eu-rES/strings.xml
+++ b/doze/res/values-eu-rES/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Keinuak</string>
-  <string name="screen_gestures_panel_summary">Erabili keinuak ekintzak burutzeko</string>
   <string name="ambient_display_title">Ambient display</string>
   <string name="ambient_display_enable_title">Ambient display</string>
   <string name="ambient_display_enable_summary">Esnatu pantaila jakinarazpenak jasotzean</string>

--- a/doze/res/values-fa/strings.xml
+++ b/doze/res/values-fa/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">حرکات</string>
-  <string name="screen_gestures_panel_summary">استفاده از حرکات برای انجام کارها</string>
   <string name="ambient_display_title">نمایش حساس به محیط</string>
   <string name="ambient_display_enable_title">نمایش حساس به محیط</string>
   <string name="ambient_display_enable_summary">روشن شدن صفحه هنگام دریافت اعلان</string>

--- a/doze/res/values-fi/strings.xml
+++ b/doze/res/values-fi/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Eleet</string>
-  <string name="screen_gestures_panel_summary">Käytä eleitä suorittaaksesi toimintoja</string>
   <string name="ambient_display_title">Ambient-näyttö</string>
   <string name="ambient_display_enable_title">Ambient-näyttö</string>
   <string name="ambient_display_enable_summary">Herätä näyttö kun saat ilmoituksia</string>

--- a/doze/res/values-fr/strings.xml
+++ b/doze/res/values-fr/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestes</string>
-  <string name="screen_gestures_panel_summary">Utiliser des gestes pour effectuer des actions</string>
   <string name="ambient_display_title">Affichage ambiant</string>
   <string name="ambient_display_enable_title">Affichage ambiant</string>
   <string name="ambient_display_enable_summary">Activer l\'écran quand vous recevez des notifications</string>

--- a/doze/res/values-gl-rES/strings.xml
+++ b/doze/res/values-gl-rES/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Xestos</string>
-  <string name="screen_gestures_panel_summary">Utilizar xestos para realizar accións</string>
   <string name="ambient_display_title">Visualización ambiental</string>
   <string name="ambient_display_enable_title">Visualización ambiental</string>
   <string name="ambient_display_enable_summary">Activar a pantalla ao recibir notificacións</string>

--- a/doze/res/values-hu/strings.xml
+++ b/doze/res/values-hu/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Mozdulatok</string>
-  <string name="screen_gestures_panel_summary">Használjon mozdulatokat műveletek végrehajtásához</string>
   <string name="ambient_display_title">Környezeti kijelző</string>
   <string name="ambient_display_enable_title">Környezeti kijelző</string>
   <string name="ambient_display_enable_summary">Képernyő ébresztése értesítések fogadásakor</string>

--- a/doze/res/values-in/strings.xml
+++ b/doze/res/values-in/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gerakan</string>
-  <string name="screen_gestures_panel_summary">Gunakan gerakan untuk melakukan sesuatu</string>
   <string name="ambient_display_title">Layar Ambient</string>
   <string name="ambient_display_enable_title">Layar Ambient</string>
   <string name="ambient_display_enable_summary">Bangunkan layar saat Anda menerima Pemberitahuan</string>

--- a/doze/res/values-it/strings.xml
+++ b/doze/res/values-it/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gesture</string>
-  <string name="screen_gestures_panel_summary">Utilizza le gesture per compiere azioni</string>
   <string name="ambient_display_title">Ambient display</string>
   <string name="ambient_display_enable_title">Ambient display</string>
   <string name="ambient_display_enable_summary">Attiva lo schermo quando ricevi notifiche</string>

--- a/doze/res/values-iw/strings.xml
+++ b/doze/res/values-iw/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">מחוות</string>
-  <string name="screen_gestures_panel_summary">השתמש במחוות לביצוע פעולות</string>
   <string name="ambient_display_title">התראות ברקע</string>
   <string name="ambient_display_enable_title">התראות ברקע</string>
   <string name="ambient_display_enable_summary">הפעל את המסך בעת קבלת התראות</string>

--- a/doze/res/values-ja/strings.xml
+++ b/doze/res/values-ja/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">ジェスチャー</string>
-  <string name="screen_gestures_panel_summary">ジェスチャーを使用してアクションを実行する</string>
   <string name="ambient_display_title">常時オンディスプレイ</string>
   <string name="ambient_display_enable_title">常時オンディスプレイ</string>
   <string name="ambient_display_enable_summary">通知を受信したときに画面を点灯する</string>

--- a/doze/res/values-kn-rIN/strings.xml
+++ b/doze/res/values-kn-rIN/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">ಸನ್ನೆಗಳು</string>
-  <string name="screen_gestures_panel_summary">ಕ್ರಿಯೆಗಳನ್ನು ನಿರ್ವಹಿಸಲು ಸನ್ನೆಗಳನ್ನು ಉಪಯೋಗಿಸಿ</string>
   <string name="ambient_display_title">ಆವರಿಸಿದ ಪರದೆ</string>
   <string name="ambient_display_enable_title">ಆವರಿಸಿದ ಪರದೆ</string>
   <string name="ambient_display_enable_summary">ನೀವು ಅಧಿಸೂಚನೆಗಳನ್ನು ಸ್ವೀಕರಿಸಿದಾಗ ಪರದೆಯನ್ನು ಎಚ್ಚರಗೊಳಿಸಿ</string>

--- a/doze/res/values-ko/strings.xml
+++ b/doze/res/values-ko/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">제스처</string>
-  <string name="screen_gestures_panel_summary">제스처를 사용하여 작업 수행</string>
   <string name="ambient_display_title">절전 모드 자동 해제</string>
   <string name="ambient_display_enable_title">절전 모드 자동 해제</string>
   <string name="ambient_display_enable_summary">알림을 수신 시 절전 모드를 해제합니다.</string>

--- a/doze/res/values-lb/strings.xml
+++ b/doze/res/values-lb/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gesten</string>
-  <string name="screen_gestures_panel_summary">Geste benotze fir Aktiounen auszeféieren</string>
   <string name="ambient_display_title">Ambiente Schierm</string>
   <string name="ambient_display_enable_title">Ambiente Schierm</string>
   <string name="ambient_display_enable_summary">Schierm waakreg maachen, wann s du Notifikatiounen empfänks</string>

--- a/doze/res/values-lt/strings.xml
+++ b/doze/res/values-lt/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestai</string>
-  <string name="screen_gestures_panel_summary">Naudoti gestus veiksmams atlikti</string>
   <string name="ambient_display_title">Ambient display</string>
   <string name="ambient_display_enable_title">Ambient display</string>
   <string name="ambient_display_enable_summary">Pažadinti ekraną, kai gaunami pranešimai</string>

--- a/doze/res/values-nb/strings.xml
+++ b/doze/res/values-nb/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Bevegelser</string>
-  <string name="screen_gestures_panel_summary">Bruk bevegelser til å utføre handlinger</string>
   <string name="ambient_display_title">Ambient skjerm</string>
   <string name="ambient_display_enable_title">Ambient skjerm</string>
   <string name="ambient_display_enable_summary">Skru på skjermen når du mottar varsler</string>

--- a/doze/res/values-nl/strings.xml
+++ b/doze/res/values-nl/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gebaren</string>
-  <string name="screen_gestures_panel_summary">Gebaren gebruiken om acties uit te voeren</string>
   <string name="ambient_display_title">Omgevingsdisplay</string>
   <string name="ambient_display_enable_title">Omgevingsdisplay</string>
   <string name="ambient_display_enable_summary">Scherm aan bij het ontvangen van meldingen</string>

--- a/doze/res/values-pl/strings.xml
+++ b/doze/res/values-pl/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gesty</string>
-  <string name="screen_gestures_panel_summary">Używaj gestów do wykonywania czynności</string>
   <string name="ambient_display_title">Aktywny wyświetlacz</string>
   <string name="ambient_display_enable_title">Aktywny wyświetlacz</string>
   <string name="ambient_display_enable_summary">Wybudź ekran, po otrzymaniu powiadomienia</string>

--- a/doze/res/values-pt-rBR/strings.xml
+++ b/doze/res/values-pt-rBR/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestos</string>
-  <string name="screen_gestures_panel_summary">Utilize gestos para executar ações</string>
   <string name="ambient_display_title">Tela ambiente</string>
   <string name="ambient_display_enable_title">Tela ambiente</string>
   <string name="ambient_display_enable_summary">Ligar a tela quando receber notificações</string>

--- a/doze/res/values-pt-rPT/strings.xml
+++ b/doze/res/values-pt-rPT/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestos</string>
-  <string name="screen_gestures_panel_summary">Utilize gestos para executar ações</string>
   <string name="ambient_display_title">Visualização de ambiente</string>
   <string name="ambient_display_enable_title">Visualização de ambiente</string>
   <string name="ambient_display_enable_summary">Ligar o ecrã quando receber notificações</string>

--- a/doze/res/values-ro/strings.xml
+++ b/doze/res/values-ro/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gesturi</string>
-  <string name="screen_gestures_panel_summary">Utilizați gesturi pentru a efectua acțiuni</string>
   <string name="ambient_display_title">Afișare ambientală</string>
   <string name="ambient_display_enable_title">Afișare ambientală</string>
   <string name="ambient_display_enable_summary">Trezește ecran când primiți notificări</string>

--- a/doze/res/values-ru/strings.xml
+++ b/doze/res/values-ru/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Жесты</string>
-  <string name="screen_gestures_panel_summary">Использовать жесты для действий</string>
   <string name="ambient_display_title">Индикация событий</string>
   <string name="ambient_display_enable_title">Индикация событий</string>
   <string name="ambient_display_enable_summary">Включать экран при получении уведомлений</string>

--- a/doze/res/values-sk/strings.xml
+++ b/doze/res/values-sk/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Gestá</string>
-  <string name="screen_gestures_panel_summary">Použite gestá na vykonávanie akcií</string>
   <string name="ambient_display_title">Ambientné zobrazenie</string>
   <string name="ambient_display_enable_title">Ambientné zobrazenie</string>
   <string name="ambient_display_enable_summary">Prebudiť obrazovku po prijatí oznámenia</string>

--- a/doze/res/values-sl/strings.xml
+++ b/doze/res/values-sl/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Poteze</string>
-  <string name="screen_gestures_panel_summary">Uporabi poteze za opravljanje dejanj</string>
   <string name="ambient_display_title">Okoliški zaslon</string>
   <string name="ambient_display_enable_title">Okoliški zaslon</string>
   <string name="ambient_display_enable_summary">Zbudi zaslon, ko prejmem obvestila</string>

--- a/doze/res/values-sr/strings.xml
+++ b/doze/res/values-sr/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Гестови</string>
-  <string name="screen_gestures_panel_summary">Користи гестове да обавиш акције</string>
   <string name="ambient_display_title">Амбијент приказ</string>
   <string name="ambient_display_enable_title">Амбијент приказ</string>
   <string name="ambient_display_enable_summary">Пробуди екран кад добијеш обавештење</string>

--- a/doze/res/values-tr/strings.xml
+++ b/doze/res/values-tr/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Hareketler</string>
-  <string name="screen_gestures_panel_summary">Eylemleri gerçekleştirmek için hareketleri kullanın</string>
   <string name="ambient_display_title">Bildirim ekranı</string>
   <string name="ambient_display_enable_title">Bildirim ekranı</string>
   <string name="ambient_display_enable_summary">Bildirim geldiğinde ekranı uyandırır</string>

--- a/doze/res/values-uk/strings.xml
+++ b/doze/res/values-uk/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">Жести</string>
-  <string name="screen_gestures_panel_summary">Користуйтеся жестами для виконання дій</string>
   <string name="ambient_display_title">Ambient display</string>
   <string name="ambient_display_enable_title">Ambient display</string>
   <string name="ambient_display_enable_summary">Вмикати екран, коли ви отримали сповіщення</string>

--- a/doze/res/values-zh-rCN/strings.xml
+++ b/doze/res/values-zh-rCN/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">手势</string>
-  <string name="screen_gestures_panel_summary">使用手势来执行动作</string>
   <string name="ambient_display_title">环境显示</string>
   <string name="ambient_display_enable_title">环境显示</string>
   <string name="ambient_display_enable_summary">当接收到通知时唤醒屏幕</string>

--- a/doze/res/values-zh-rTW/strings.xml
+++ b/doze/res/values-zh-rTW/strings.xml
@@ -14,7 +14,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string name="screen_gestures_panel_title">手勢</string>
-  <string name="screen_gestures_panel_summary">使用手勢來執行操作</string>
   <string name="ambient_display_title">環境顯示</string>
   <string name="ambient_display_enable_title">環境顯示</string>
   <string name="ambient_display_enable_summary">當您收到通知時喚醒螢幕</string>

--- a/doze/res/values/strings.xml
+++ b/doze/res/values/strings.xml
@@ -15,7 +15,6 @@
 
     <!-- Gesture shortcuts -->
     <string name="screen_gestures_panel_title">Gestures</string>
-    <string name="screen_gestures_panel_summary">Use gestures to perform actions</string>
 
     <string name="ambient_display_title">Ambient display</string>
 


### PR DESCRIPTION
  The gestures settings are the only settings on the
  main screen to contain a summary line, and it looks
  extremely out of place.

Change-Id: I2cacef71e8db204ab4380f77d9282009e0e5df03
Signed-off-by: KhasMek Boushh@gmail.com
